### PR TITLE
List all annotations after editing one

### DIFF
--- a/app/classifier.cjsx
+++ b/app/classifier.cjsx
@@ -16,10 +16,7 @@ module.exports = React.createClass
   render: ->
     <div className="readymade-classification-interface">
       <div className="readymade-decision-tree-container">
-        <AnnotationToolbar onClick={@onToolbarClick} addTool={@newAnnotation} onFinish={@onFinishPage} />
-        {@state.annotations.map (tool) =>
-          <Annotation key={tool.id} tool={tool} delete={@deleteAnnotation} />
-        } 
+        <AnnotationToolbar annotations={@state.annotations} onClick={@onToolbarClick} addTool={@newAnnotation} deleteTool={@deleteAnnotation} onFinish={@onFinishPage} />
         <ClassificationSummary />
       </div>
       <div className="readymade-subject-viewer-container">
@@ -52,6 +49,7 @@ module.exports = React.createClass
     annotations = @state.annotations
     index = annotations.indexOf annotation
     annotations.splice index, 1
+    annotation.destroy()
     @setState {annotations}
 
   load: (subject) ->

--- a/app/classify/annotation-toolbar.cjsx
+++ b/app/classify/annotation-toolbar.cjsx
@@ -1,6 +1,7 @@
 React = require 'react'
 ChooseTask = require './tasks/choose'
 EditTask = require './tasks/edit'
+Annotation = require './annotation'
 
 module.exports = React.createClass
   displayName: 'AnnotationToolbar'
@@ -13,7 +14,12 @@ module.exports = React.createClass
     <div className="decision-tree">
         {switch @state.step
           when 'choose'
-            <ChooseTask onChooseTask={@edit} onFinish={@finish} />
+            <div>
+              <ChooseTask onChooseTask={@edit} onFinish={@finish} />
+              {@props.annotations.map (tool) =>
+                <Annotation key={tool.id} tool={tool} delete={@props.deleteTool} />
+              }
+            </div>
           when 'edit'
             <EditTask type={@state.type} onClick={@selectText} onComplete={@choose}/>
         }

--- a/app/classify/annotation.cjsx
+++ b/app/classify/annotation.cjsx
@@ -14,9 +14,6 @@ module.exports = React.createClass
   labels:
     health: 'Health Issue'
     welfare: 'Welfare Issue'
-    
-  componentWillUnmount: ->
-    range.destroy() for range in @props.tool.ranges
   
   render: ->
     <div>

--- a/app/lib/annotation-tool.coffee
+++ b/app/lib/annotation-tool.coffee
@@ -12,4 +12,7 @@ class AnnotationTool
   addRange: (rangeTool) ->
     @ranges.push rangeTool
   
+  destroy: ->
+    range.destroy() for range in @ranges
+  
 module.exports = AnnotationTool


### PR DESCRIPTION
Move the list of annotations from the classify page to the toolbar.
Don't show the list when editing a new annotation.
Destroy any text ranges when we destroy an annotation.
