### PR TITLE
Make classification subjects an array

### DIFF
--- a/app/classifier.cjsx
+++ b/app/classifier.cjsx
@@ -6,6 +6,7 @@ Annotation = require './classify/annotation'
 AnnotationToolbar = require './classify/annotation-toolbar'
 ClassificationSummary = require './classify/summary'
 AnnotationTool = require './lib/annotation-tool'
+SelectionTool = require './lib/selection-tool'
 Subjects = require './lib/subjects'
 Classifications = require './lib/classifications'
 {tasks} = require './config'
@@ -18,7 +19,7 @@ module.exports = React.createClass
   
   getInitialState: ->
     annotations: []
-    currentSubject: null
+    currentSubjects: []
   
   componentWillMount: ->
     @subjects = new Subjects @props.api, @props.project, @props.subject_set?.id
@@ -43,10 +44,10 @@ module.exports = React.createClass
       </div>
       <div className="readymade-subject-viewer-container">
         {
-          if @state.currentSubject?
+          if @state.currentSubjects.length
             <div className="readymade-subject-viewer">
-              <SubjectTools project={@props.project} api={@props.api} talk={@props.talk} user={@props.user} subject_set={@props.subject_set} subject={@state.currentSubject} />
-              <SubjectViewer subject={@state.currentSubject} ref='subject_viewer' />
+              <SubjectTools project={@props.project} api={@props.api} talk={@props.talk} user={@props.user} subject_set={@props.subject_set} subject={@state.currentSubjects[0]} />
+              {<SubjectViewer subject={subject} key={subject.id} /> for subject in @state.currentSubjects}
             </div>
         }
       </div>
@@ -64,12 +65,12 @@ module.exports = React.createClass
     @classifications?.set_annotations ({task: key, value: value} for key, value of task_annotations)
     
   onToolbarClick: (e) ->
-    @addText @refs.subject_viewer.createSelection e.currentTarget.value
+    @addText @createSelection e.currentTarget.value
   
   onFinishPage: ->
     @classifications.finish()
     console.log JSON.stringify @classifications.current()
-    console.log @state.currentSubject?.metadata.image
+    console.log @state.currentSubjects[0]?.metadata.image
     @classifications.current().save()
     @reset()
     @nextSubject()
@@ -94,14 +95,21 @@ module.exports = React.createClass
     @setState {annotations}
     
   nextSubject: ->
-    currentSubject = @subjects.next()
+    currentSubjects = [@subjects.next(), @subjects.queue[0]]
     # create a new classification here
-    @classifications.create currentSubject if currentSubject?
-    @setState {currentSubject}
+    @classifications.create currentSubjects if currentSubjects.length
+    @setState {currentSubjects}
 
   reset: ->
     annotations = @state.annotations
     annotation.destroy() for annotation in annotations
     annotations = []
-    currentSubject = null
-    @setState {annotations, currentSubject}
+    currentSubjects = []
+    @setState {annotations, currentSubjects}
+  
+  createSelection: (type) ->
+    sel = document.getSelection()
+    if sel.rangeCount
+      options =
+        type: type
+      tool = new SelectionTool options

--- a/app/classifier.cjsx
+++ b/app/classifier.cjsx
@@ -47,7 +47,9 @@ module.exports = React.createClass
           if @state.currentSubjects.length
             <div className="readymade-subject-viewer">
               <SubjectTools project={@props.project} api={@props.api} talk={@props.talk} user={@props.user} subject_set={@props.subject_set} subject={@state.currentSubjects[0]} />
-              {<SubjectViewer subject={subject} key={subject.id} /> for subject in @state.currentSubjects}
+              <div className="scroll-container">
+                {<SubjectViewer subject={subject} key={subject.id} /> for subject in @state.currentSubjects}
+              </div>
             </div>
         }
       </div>

--- a/app/classify/subject-viewer.cjsx
+++ b/app/classify/subject-viewer.cjsx
@@ -1,7 +1,5 @@
 React = require 'react'
 
-SelectionTool = require '../lib/selection-tool'
-
 module.exports = React.createClass
   displayName: 'SubjectViewer'
   
@@ -21,20 +19,13 @@ module.exports = React.createClass
     <div className="readymade-marking-surface-container">
       <div className="text-viewer">
         <h3>Page text</h3>
-        <div ref = 'textViewer'>{@state.text}</div>
+        <div data-subject={@props.subject.id}>{@state.text}</div>
       </div>
       <div className="subject-image">
         <h3>Scanned page</h3>
         {<img src={image} alt="" /> if image}
       </div>
     </div>
-  
-  createSelection: (type) ->
-    sel = document.getSelection()
-    if sel.rangeCount
-      options =
-        type: type
-      tool = new SelectionTool options
   
   fetchOCR: (url) ->
     fetch url

--- a/app/lib/classifications.coffee
+++ b/app/lib/classifications.coffee
@@ -12,7 +12,7 @@ class Classifications
   update: (opts) ->
     @[opt] = value for opt, value of opts
     
-  create: (subject)->
+  create: (subjects)->
     @classification = @api
       .type('classifications')
       .create
@@ -26,7 +26,7 @@ class Classifications
         links:
           project: @project?.id.toString()
           workflow: @workflow?.id
-          subjects: [subject.id]
+          subjects: (subject.id for subject in subjects)
   
   set_annotations: (annotations) ->
     @classification?.annotations = annotations

--- a/app/lib/selection-tool.coffee
+++ b/app/lib/selection-tool.coffee
@@ -12,6 +12,7 @@ class SelectionTool
     {start, end} = @getNodePosition()
     @annotation =
       type: @type
+      subject: @text.getAttribute 'data-subject'
       text: @el.textContent
       start: start
       end: end

--- a/css/annotations.styl
+++ b/css/annotations.styl
@@ -212,3 +212,14 @@ button[disabled]
         position: relative
         top: 50%
         transform: translateY(-50%)
+
+.scroll-container
+  max-height: 90vh
+  overflow: scroll
+  
+.decision-tree
+.readymade-classification-summary
+  padding: .5em
+  border-radius: .5em
+  background: #333
+  background: rgba(0, 0, 0, 0.5)


### PR DESCRIPTION
Move text selection out of the subject viewer
Add subject ID to the annotation data.
Closes #27

Allows for annotating more than one page at a time. Classifications are submitted for the first page in the sequence.