### PR TITLE
Beta feedback changes

### DIFF
--- a/app/classifier.cjsx
+++ b/app/classifier.cjsx
@@ -1,9 +1,8 @@
 React = require 'react'
 
-SubjectTools = require './classify/subject-tools'
-SubjectViewer = require './classify/subject-viewer'
 Annotation = require './classify/annotation'
 ClassificationTask = require './classify/classification-task'
+Subject = require './classify/subject'
 Subjects = require './lib/subjects'
 Classifications = require './lib/classifications'
 
@@ -35,28 +34,14 @@ module.exports = React.createClass
       
   render: ->
     <ClassificationTask onChange={@onChangeAnnotation} onFinish={@onFinishPage}>
-      <div className="readymade-subject-viewer-container">
-        {
-          if @state.currentSubjects.length
-            <div className="readymade-subject-viewer">
-              <SubjectTools project={@props.project} api={@props.api} talk={@props.talk} user={@props.user} subject_set={@props.subject_set} subject={@state.currentSubjects[0]} />
-              <div className="scroll-container" ref="scrollContainer">
-                {<SubjectViewer subject={subject} key={subject.id} ref="subject#{subject.id}" isCurrent={subject.id is @subjects.current.id} /> for subject in @state.currentSubjects}
-              </div>
-            </div>
-        }
-      </div>
+      <Subject project={@props.project} api={@props.api} talk={@props.talk} user={@props.user} subject_set={@props.subject_set} currentSubjects={@state.currentSubjects} />
     </ClassificationTask>
   
   onChangeAnnotation: (annotation) ->
-    if annotation.issue
-      @refs["subject#{subject.id}"].getDOMNode().classList.add 'active' for subject in @state.currentSubjects
-    else
-      @refs["subject#{subject.id}"].getDOMNode().classList.remove 'active' for subject in @state.currentSubjects
 
   onFinishPage: (task_annotations) ->
     @classifications?.set_annotations ({task: key, value: value} for key, value of task_annotations)
-    @classifications.finish()
+    # @classifications.finish()
     console.log JSON.stringify @classifications.current()
     console.log @state.currentSubjects[0]?.metadata.image
     @nextSubject()

--- a/app/classifier.cjsx
+++ b/app/classifier.cjsx
@@ -32,21 +32,6 @@ module.exports = React.createClass
         @subjects.flush()
         @subjects.fetch()
           .then @nextSubject
-  
-  componentDidUpdate: ->
-    return unless @subjects.current?
-    container = @refs.scrollContainer?.getDOMNode()
-    subject_node = @refs["subject#{@subjects.current.id}"]?.getDOMNode()
-    return unless container? && subject_node?
-    
-    container.scrollTop -= subject_node.scrollHeight
-    distance = subject_node.offsetTop / 20
-    
-    move_subject = =>
-      container.scrollTop = container.scrollTop + distance
-      setTimeout move_subject, 50 unless container.scrollTop > subject_node.offsetTop - 50
-    
-    setTimeout move_subject, 50
       
   render: ->
     <ClassificationTask onChange={@onChangeAnnotation} onFinish={@onFinishPage}>
@@ -77,13 +62,7 @@ module.exports = React.createClass
     @nextSubject()
     
   nextSubject: ->
-    currentSubjects = @state.currentSubjects
-    if currentSubjects.length is 0
-      currentSubjects.push @subjects.next(), @subjects.queue[0]
-    else
-      @subjects.next()
-      currentSubjects.push @subjects.queue[0]
-      currentSubjects.shift() if currentSubjects.length > 3
+    currentSubjects = [@subjects.next()]
     # create a new classification here
     @classifications.create [@subjects.current]
     # remove undefined or null subjects from currentSubjects

--- a/app/classifier.cjsx
+++ b/app/classifier.cjsx
@@ -34,10 +34,11 @@ module.exports = React.createClass
       
   render: ->
     <ClassificationTask onChange={@onChangeAnnotation} onFinish={@onFinishPage}>
-      <Subject project={@props.project} api={@props.api} talk={@props.talk} user={@props.user} subject_set={@props.subject_set} currentSubjects={@state.currentSubjects} />
+      <Subject ref='subject' project={@props.project} api={@props.api} talk={@props.talk} user={@props.user} subject_set={@props.subject_set} subject={@state.currentSubjects[0]} />
     </ClassificationTask>
   
   onChangeAnnotation: (annotation) ->
+    @refs.subject.onChange annotation
 
   onFinishPage: (task_annotations) ->
     @classifications?.set_annotations ({task: key, value: value} for key, value of task_annotations)

--- a/app/classifier.cjsx
+++ b/app/classifier.cjsx
@@ -23,10 +23,10 @@ module.exports = React.createClass
   
   componentWillReceiveProps: (newProps)->
     {api, project, subject_set, workflow} = newProps
-    @subjects.update {api, project, subject_set_id: subject_set.id}
+    @subjects.update {api, project, subject_set_id: subject_set?.id}
     @classifications.update {api, project, workflow}
     
-    if newProps.user != @props.user || newProps.subject_set.id != @props.subject_set.id
+    if newProps.user != @props.user 
       @setState currentSubjects: [], =>
         @subjects.flush()
         @subjects.fetch()

--- a/app/classify/annotation.cjsx
+++ b/app/classify/annotation.cjsx
@@ -6,9 +6,9 @@ TextRange = React.createClass
   
   render: ->
     annotation = @props.range?.annotation ? ''
-    <p className="text-selection">
+    <span>
       {annotation.text} 
-    </p>
+    </span>
 
 module.exports = React.createClass
   displayName: 'Annotation'
@@ -16,10 +16,9 @@ module.exports = React.createClass
   tasks: tasks
   
   render: ->
-    <div className="annotation #{@props.tool.type}">
-      {@tasks[@props.tool.type].label} <button className="secret-button" aria-label='Edit' onClick={@edit}><span className="fa fa-pencil-square-o"></span></button>
+    <button className="standard-button annotation #{@props.tool.type}" onClick={@edit}>
       <TextRange range={@props.tool.issue} />
-    </div>
+    </button>
   
   edit: (e) ->
     @props.edit @props.tool

--- a/app/classify/annotation.cjsx
+++ b/app/classify/annotation.cjsx
@@ -6,7 +6,7 @@ TextRange = React.createClass
   
   render: ->
     annotation = @props.range.annotation
-    <p className="text-selection #{annotation.type}">
+    <p className="text-selection">
       {annotation.text} 
     </p>
 
@@ -16,7 +16,7 @@ module.exports = React.createClass
   tasks: tasks
   
   render: ->
-    <div className="annotation">
+    <div className="annotation #{@props.tool.type}">
       {@tasks[@props.tool.type].label} <button className="secret-button" aria-label='Edit' onClick={@edit}><span className="fa fa-pencil-square-o"></span></button>
       <TextRange range={@props.tool.issue} />
     </div>

--- a/app/classify/annotation.cjsx
+++ b/app/classify/annotation.cjsx
@@ -6,9 +6,9 @@ TextRange = React.createClass
   
   render: ->
     annotation = @props.range.annotation
-    <li className="highlight #{annotation.type}">
+    <p className="text-selection #{annotation.type}">
       {annotation.text} 
-    </li>
+    </p>
 
 module.exports = React.createClass
   displayName: 'Annotation'
@@ -18,9 +18,7 @@ module.exports = React.createClass
   render: ->
     <div className="annotation">
       {@tasks[@props.tool.type].label} <button className="secret-button" aria-label='Edit' onClick={@edit}><span className="fa fa-pencil-square-o"></span></button>
-      <ul>
-        <TextRange range={@props.tool.issue} />
-      </ul>
+      <TextRange range={@props.tool.issue} />
     </div>
   
   edit: (e) ->

--- a/app/classify/annotation.cjsx
+++ b/app/classify/annotation.cjsx
@@ -5,7 +5,7 @@ TextRange = React.createClass
   displayName: 'TextRange'
   
   render: ->
-    annotation = @props.range.annotation
+    annotation = @props.range?.annotation ? ''
     <p className="text-selection">
       {annotation.text} 
     </p>

--- a/app/classify/classification-task.cjsx
+++ b/app/classify/classification-task.cjsx
@@ -63,7 +63,7 @@ module.exports = React.createClass
                   <ChooseTask onChooseTask={@create} onBack={@reset} onFinish={@finish} />
                 </div>
               when 'edit'
-                <EditTask annotation={@state.annotations[0]} onChange={@onChange} onComplete={@choose}/>
+                <EditTask annotation={@currentAnnotation()} onChange={@onChange} onComplete={@choose}/>
             }
           </div>
         </div>
@@ -110,7 +110,7 @@ module.exports = React.createClass
   edit: (annotation) ->
 
     if @state.step is 'edit'
-      @completeAnnotation @state.annotations[0], => @editAnnotation annotation
+      @completeAnnotation @currentAnnotation(), => @editAnnotation annotation
     else
       @editAnnotation annotation
     @props.onChange annotation
@@ -174,6 +174,9 @@ module.exports = React.createClass
     annotations.splice index, 1
     annotation.destroy()
     @setState {annotations}
+  
+  currentAnnotation: ->
+    @state.annotations[0]
   
   completeAnnotation: (annotation, callback = () -> ) ->
     annotations = @state.annotations

--- a/app/classify/classification-task.cjsx
+++ b/app/classify/classification-task.cjsx
@@ -89,16 +89,16 @@ module.exports = React.createClass
       type: type
       instructions: tasks[type]
   
-  edit: (tool) ->
-    tool.issue?.el.classList.remove 'complete'
-    for type, ranges of tool.subtasks
+  edit: (annotation) ->
+    annotation.issue?.el.classList.remove 'complete'
+    for type, ranges of annotation.subtasks
       ranges.map (range) -> range.el.classList.remove 'complete'
-    @editAnnotation tool
+    @editAnnotation annotation
     @setState 
       step: 'edit'
-      type: tool.type
-      instructions: tasks[tool.type]
-    @props.onChange tool
+      type: annotation.type
+      instructions: tasks[annotation.type]
+    @props.onChange annotation
   
   choose: (annotation) ->
     annotations = @state.annotations

--- a/app/classify/classification-task.cjsx
+++ b/app/classify/classification-task.cjsx
@@ -41,6 +41,7 @@ module.exports = React.createClass
     description: "Find a health issue on this page that fits one of the categories below. Your task is to collect all the information on the page about the issue you've found."
   
   getInitialState: ->
+    relevant: null
     step: 'filter'
     type: 'health'
     instructions: @defaultInstructions
@@ -73,12 +74,13 @@ module.exports = React.createClass
   filter: (choice) ->
     switch choice
       when 'yes'
-        @setState 
+        @setState
+          relevant: 'yes'
           step: 'choose'
           type: null
           instructions: @defaultInstructions
       when 'no'
-        @finish()
+        @setState relevant: 'no', @finish
 
   create: (type) ->
     @newAnnotation type
@@ -125,12 +127,13 @@ module.exports = React.createClass
     @setState {annotations, step}
     
   finish: ->
-    task_annotations = {}
+    marking_annotations = []
     @state.annotations.map (annotation, i) ->
-      task_annotations[annotation.type] ?= []
-      task_annotations[annotation.type].push annotation.value()
-    task_annotations[task] ?= [] for task of tasks
-    @props.onFinish task_annotations
+      marking_annotations.push annotation.value()
+    annotations =
+      T1: @state.relevant
+      T2: marking_annotations 
+    @props.onFinish annotations
     annotations = @state.annotations
     annotation.destroy() for annotation in annotations
     annotations = []

--- a/app/classify/classification-task.cjsx
+++ b/app/classify/classification-task.cjsx
@@ -23,6 +23,7 @@ AnnotationsSummary = React.createClass
     
   render: ->
     <div className="annotation-summary">
+    {<h2>Health issues</h2> if @props.annotations.length}
     {if @props.annotations.length then @props.annotations.map (tool) =>
       <Annotation key={tool.id} tool={tool} delete={@props.deleteTool} edit={@edit} />
     else

--- a/app/classify/classification-task.cjsx
+++ b/app/classify/classification-task.cjsx
@@ -118,8 +118,11 @@ module.exports = React.createClass
   
   newAnnotation: (type) ->
     annotations = @state.annotations
-    annotations.unshift new AnnotationTool type
+    annotation = new AnnotationTool type
+    annotation.addIssue()
+    annotations.unshift annotation
     @setState {annotations}
+    @props.onChange annotation
   
   editAnnotation: (annotation) ->
     annotations = @state.annotations

--- a/app/classify/subject-tools.cjsx
+++ b/app/classify/subject-tools.cjsx
@@ -11,11 +11,25 @@ module.exports = React.createClass
   
   getInitialState: ->
     fieldGuideHidden: true
+    subject_set:
+      display_name: ''
+      metadata:
+        BOROUGH: ''
+        Date: ''
+  
+  componentWillMount: ->
+    subject_set_id = @props.subject?.links.subject_sets[0]
+    @updateSubjectSet subject_set_id
+    
+  componentWillReceiveProps: (newProps) ->
+    new_id = newProps.subject.links.subject_sets[0]
+    if new_id != @props.subject.links.subject_sets[0]
+      @updateSubjectSet new_id
   
   render: ->
     <div>
       <div className="drawing-controls">
-        <h2>{@props.subject_set.metadata.BOROUGH} {@props.subject_set.metadata.Date} ({@props.subject_set.display_name}) {<span>Page {@props.subject.metadata.page}</span> if @props.subject?}</h2>
+        <h2>{@state.subject_set.metadata.BOROUGH} {@state.subject_set.metadata.Date} ({@state.subject_set.display_name}) {<span>Page {@props.subject.metadata.page}</span> if @props.subject?}</h2>
         <span className="tools">
           <label className="readymade-has-clickable"> 
             <input type="checkbox" name="examples" checked={!@state.fieldGuideHidden} onChange={@toggleFieldGuide} /> 
@@ -50,3 +64,7 @@ module.exports = React.createClass
       .then ([tutorial]) =>
         alert (resolve) =>
           <Tutorial tutorial={tutorial} api={@props.api} user={@props.user} project={@props.project} onFinish={resolve} />
+  updateSubjectSet: (subject_set_id) ->
+    @props.api.type('subject_sets').get subject_set_id
+      .then (subject_set) =>
+        @setState {subject_set}

--- a/app/classify/subject-tools.cjsx
+++ b/app/classify/subject-tools.cjsx
@@ -15,7 +15,7 @@ module.exports = React.createClass
   render: ->
     <div>
       <div className="drawing-controls">
-        <h2>{@props.subject_set.metadata.BOROUGH} {@props.subject_set.metadata.Date} ({@props.subject_set.display_name})</h2>
+        <h2>{@props.subject_set.metadata.BOROUGH} {@props.subject_set.metadata.Date} ({@props.subject_set.display_name}) {<span>Page {@props.subject.metadata.page}</span> if @props.subject?}</h2>
         <span className="tools">
           <label className="readymade-has-clickable"> 
             <input type="checkbox" name="examples" checked={!@state.fieldGuideHidden} onChange={@toggleFieldGuide} /> 

--- a/app/classify/subject-viewer.cjsx
+++ b/app/classify/subject-viewer.cjsx
@@ -16,7 +16,7 @@ module.exports = React.createClass
   
   render: ->
     classList=["readymade-marking-surface-container"]
-    classList.push 'image' if @props.task is 'filter'
+    classList.push @props.mode
     classList.push 'active' if @props.active
     image = @mediaSrcs['image/jpeg']
     <div className={classList.join ' '}>

--- a/app/classify/subject-viewer.cjsx
+++ b/app/classify/subject-viewer.cjsx
@@ -16,15 +16,14 @@ module.exports = React.createClass
   
   render: ->
     classList=["readymade-marking-surface-container"]
-    classList.push "current" if @props.isCurrent
+    classList.push 'image' if @props.task is 'filter'
     image = @mediaSrcs['image/jpeg']
     <div className={classList.join ' '}>
       <div className="text-viewer">
         <div data-subject={@props.subject.id}>{@state.text}</div>
       </div>
       <div className="subject-image">
-        <h3>Scanned page</h3>
-        {<img src={image} alt="" /> if image}
+        {<img src={image} alt={@state.text} /> if image}
       </div>
     </div>
   

--- a/app/classify/subject-viewer.cjsx
+++ b/app/classify/subject-viewer.cjsx
@@ -17,6 +17,7 @@ module.exports = React.createClass
   render: ->
     classList=["readymade-marking-surface-container"]
     classList.push 'image' if @props.task is 'filter'
+    classList.push 'active' if @props.active
     image = @mediaSrcs['image/jpeg']
     <div className={classList.join ' '}>
       <div className="text-viewer">

--- a/app/classify/subject-viewer.cjsx
+++ b/app/classify/subject-viewer.cjsx
@@ -20,7 +20,6 @@ module.exports = React.createClass
     image = @mediaSrcs['image/jpeg']
     <div className={classList.join ' '}>
       <div className="text-viewer">
-        <h3>Page {@props.subject.metadata.page}</h3>
         <div data-subject={@props.subject.id}>{@state.text}</div>
       </div>
       <div className="subject-image">

--- a/app/classify/subject.cjsx
+++ b/app/classify/subject.cjsx
@@ -5,16 +5,33 @@ SubjectViewer = require './subject-viewer'
 module.exports = React.createClass
   displayName: 'Subject'
   
+  getInitialState: ->
+    currentSubjects: []
+
+  componentWillReceiveProps: (newProps) ->
+    {nextSubjectIds, prevSubjectIds} = newProps.subject.metadata
+    @props.api.type('subjects')
+      .get([nextSubjectIds[0], prevSubjectIds[0]])
+      .then (subjects) =>
+        @setState currentSubjects: [subjects[1], newProps.subject, subjects[0]]
+  
   render: ->
     console.log @props.task 
     <div className="readymade-subject-viewer-container">
       {
-        if @props.currentSubjects.length
+        if @state.currentSubjects.length
           <div className="readymade-subject-viewer">
-            <SubjectTools project={@props.project} api={@props.api} talk={@props.talk} user={@props.user} subject_set={@props.subject_set} subject={@props.currentSubjects[0]} />
+            <SubjectTools project={@props.project} api={@props.api} talk={@props.talk} user={@props.user} subject_set={@props.subject_set} subject={@props.subject} />
             <div className="scroll-container" ref="scrollContainer">
-              {<SubjectViewer task={@props.task} subject={subject} key={subject.id} ref="subject#{subject.id}" /> for subject in @props.currentSubjects}
+              {<SubjectViewer task={@props.task} subject={subject} key={subject.id} active={subject is @props.subject} ref="subject#{subject.id}" /> for subject in @state.currentSubjects}
             </div>
           </div>
       }
     </div>
+  
+  onChange: (annotation) ->
+    if annotation.issue
+      @refs["subject#{subject.id}"].getDOMNode().classList.add 'active' for subject in @state.currentSubjects
+    else
+      @refs["subject#{subject.id}"].getDOMNode().classList.remove 'active' for subject in @state.currentSubjects
+      @refs["subject#{@props.subject.id}"].getDOMNode().classList.add 'active'

--- a/app/classify/subject.cjsx
+++ b/app/classify/subject.cjsx
@@ -1,0 +1,20 @@
+React = require 'react'
+SubjectTools = require './subject-tools'
+SubjectViewer = require './subject-viewer'
+
+module.exports = React.createClass
+  displayName: 'Subject'
+  
+  render: ->
+    console.log @props.task 
+    <div className="readymade-subject-viewer-container">
+      {
+        if @props.currentSubjects.length
+          <div className="readymade-subject-viewer">
+            <SubjectTools project={@props.project} api={@props.api} talk={@props.talk} user={@props.user} subject_set={@props.subject_set} subject={@props.currentSubjects[0]} />
+            <div className="scroll-container" ref="scrollContainer">
+              {<SubjectViewer task={@props.task} subject={subject} key={subject.id} ref="subject#{subject.id}" /> for subject in @props.currentSubjects}
+            </div>
+          </div>
+      }
+    </div>

--- a/app/classify/subject.cjsx
+++ b/app/classify/subject.cjsx
@@ -11,6 +11,7 @@ module.exports = React.createClass
     viewAll: false
 
   componentWillReceiveProps: (newProps) ->
+    return unless newProps.subject?
     {nextSubjectIds, prevSubjectIds} = newProps.subject.metadata
     @props.api.type('subjects')
       .get([nextSubjectIds[0], prevSubjectIds[0]])

--- a/app/classify/subject.cjsx
+++ b/app/classify/subject.cjsx
@@ -21,7 +21,7 @@ module.exports = React.createClass
       {
         if @state.currentSubjects.length
           <div className="readymade-subject-viewer">
-            <SubjectTools project={@props.project} api={@props.api} talk={@props.talk} user={@props.user} subject_set={@props.subject_set} subject={@props.subject} />
+            <SubjectTools project={@props.project} api={@props.api} talk={@props.talk} user={@props.user} subject={@props.subject} />
             <div className="scroll-container" ref="scrollContainer">
               {<SubjectViewer task={@props.task} subject={subject} key={subject.id} active={subject is @props.subject} ref="subject#{subject.id}" /> for subject in @state.currentSubjects}
             </div>

--- a/app/classify/tasks/choose.cjsx
+++ b/app/classify/tasks/choose.cjsx
@@ -13,7 +13,7 @@ module.exports = React.createClass
       <ul className="decision-tree-choices">
         {for key, task of tasks
           <li key={key} className="decision-tree-choice">
-            <button className="readymade-choice-clickable standard-button" value={key} onClick={@edit}>
+            <button className="readymade-choice-clickable standard-button #{key}" value={key} onClick={@edit}>
               <span className="readymade-choice-label">{task.label}</span>
             </button> 
           </li>

--- a/app/classify/tasks/choose.cjsx
+++ b/app/classify/tasks/choose.cjsx
@@ -9,6 +9,7 @@ module.exports = React.createClass
       <div className="decision-tree-question">
         To get started first select the category
       </div>
+      <button type="button" className="decision-tree-choice major-button" onClick={@back}>Back</button>
       <ul className="decision-tree-choices">
         {for key, task of tasks
           <li key={key} className="decision-tree-choice">
@@ -17,14 +18,17 @@ module.exports = React.createClass
             </button> 
           </li>
         }
-        {@props.children}
-        <button type="button" className="major-button" onClick={@finish}>Finish page</button>
       </ul>
+      {@props.children}
+      <button type="button" className="major-button" onClick={@finish}>Finish page</button>
     </div>
   
   edit: (e) ->
     @props.onChooseTask e.currentTarget.value
   
+  back: ->
+    @props.onBack()
+
   finish: ->
     @props.onFinish()
 

--- a/app/classify/tasks/edit.cjsx
+++ b/app/classify/tasks/edit.cjsx
@@ -77,6 +77,7 @@ module.exports = React.createClass
       <div className="decision-tree-question">
         {@instructions}
       </div>
+      <button type="button" className="decision-tree-choice major-button" onClick={@done}>Back</button>
       <ToolList annotation={@state.annotation} tools={tools} addText={@addText} deleteText={@deleteText}>
       </ToolList>
       <div className="decision-tree-confirmation">

--- a/app/classify/tasks/edit.cjsx
+++ b/app/classify/tasks/edit.cjsx
@@ -7,11 +7,14 @@ TextSelection = React.createClass
   getDefaultProps: ->
     range: {}
   
-  render: ->
-    <p className="text-selection"><button className="secret-button" aria-label='Delete' onClick={@delete}>X</button> {@props.range.annotation.text}</p>
-  
   delete: (e) ->
     @props.onDelete @props.range
+  
+  render: ->
+    <p className="text-selection">
+      <button className="secret-button" aria-label='Delete' onClick={@delete}>X</button>
+      {@props.range.annotation.text}
+    </p>
 
 ToolList = React.createClass
   displayName: 'ToolList'
@@ -69,6 +72,10 @@ module.exports = React.createClass
   
   componentWillMount: ->
     annotation = @props.annotation
+    @setState {annotation}
+  
+  componentWillReceiveProps: (newProps) ->
+    annotation = newProps.annotation
     @setState {annotation}
   
   render: ->

--- a/app/classify/tasks/filter.cjsx
+++ b/app/classify/tasks/filter.cjsx
@@ -26,7 +26,7 @@ module.exports = React.createClass
       </div>
       <div className="decision-tree-choices">
         {for key, answer of answers
-          <label className="decision-tree-choice">
+          <label key={key} className="decision-tree-choice">
             <input type="radio" name={@props.name} value={answer.value} checked={@state.value is answer.value} onChange={@choose} />
             <span className="readymade-choice-clickable standard-button">{answer.label}</span>
           </label> 

--- a/app/classify/tasks/filter.cjsx
+++ b/app/classify/tasks/filter.cjsx
@@ -1,0 +1,45 @@
+React = require 'react'
+
+answers =
+  yes:
+    label: 'Yes'
+    value: 'yes'
+  no:
+    label: 'No'
+    value: 'no'
+
+module.exports = React.createClass
+  displayName: 'FilterTask'
+  
+  getDefaultProps: ->
+    name: 'filter'
+    
+  getInitialState: ->
+    value: null
+  
+  render: ->
+    label = 'Next'
+    label = 'Finish' if @state.value is 'no'
+    <div className="decision-tree-task">
+      <div className="decision-tree-question">
+        Are there any health issues to mark on this page?
+      </div>
+      <div className="decision-tree-choices">
+        {for key, answer of answers
+          <label className="decision-tree-choice">
+            <input type="radio" name={@props.name} value={answer.value} checked={@state.value is answer.value} onChange={@choose} />
+            <span className="readymade-choice-clickable standard-button">{answer.label}</span>
+          </label> 
+        }
+        {@props.children}
+        <button type="button" className="major-button" onClick={@complete} disabled={!@state.value}>{label}</button>
+      </div>
+    </div>
+  
+  choose: (e) ->
+    @setState value: e.currentTarget.value
+  
+  complete: ->
+    @props.onComplete @state.value
+    @setState value: null
+

--- a/app/classify/tutorial.cjsx
+++ b/app/classify/tutorial.cjsx
@@ -33,7 +33,7 @@ module.exports = React.createClass
     selected: 0
   
   componentDidMount: ->
-    @refs.continue.getDOMNode().focus()
+    @refs.continue.focus()
   
   render: ->
     if @state.selected == @props.tutorial.steps.length - 1

--- a/app/config.coffee
+++ b/app/config.coffee
@@ -11,7 +11,7 @@ module.exports =
     host: 'https://talk.zooniverse.org'
     root: ''
   tasks:
-    health: 
+    pollution: 
       label: 'Pollution and Waste'
       description: 'Monitoring environmental health and sanitation was a major part of the Medical Officer’s role. They reported on contaminated water, noxious fumes and smells and sewerage and drainage. They monitored the health effects of seasonal changes in temperature and smog levels. They also directed the clean-up of areas that were a potential health hazard, removing piles of rubbish, stopping effluent run-off.'
       tools: [{

--- a/app/lib/annotation-tool.coffee
+++ b/app/lib/annotation-tool.coffee
@@ -55,6 +55,7 @@ class AnnotationTool
   
   createSelection: (type) ->
     sel = document.getSelection()
+    return null unless sel.anchorNode?.parentNode.getAttribute 'data-subject'
     if sel.rangeCount
       options =
         type: type

--- a/app/lib/annotation-tool.coffee
+++ b/app/lib/annotation-tool.coffee
@@ -12,7 +12,7 @@ class AnnotationTool
     @id = "#{@type}-#{AnnotationTool.count}"
     @subtasks = {}
   
-  addIssue: (type) ->
+  addIssue: (type = 'issue') ->
     if @issue?
       document.getSelection().removeAllRanges()
     else
@@ -27,6 +27,7 @@ class AnnotationTool
     
   addSubtask: (type) ->
     rangeTool = @createSelection type
+    return unless rangeTool?
     rangeTool.el.classList.add @type
     @subtasks[rangeTool.type] ?= []
     @subtasks[rangeTool.type].push rangeTool

--- a/app/lib/annotation-tool.coffee
+++ b/app/lib/annotation-tool.coffee
@@ -42,10 +42,13 @@ class AnnotationTool
     !@issue?
   
   value: ->
-    issue = @issue?.annotation
+    value = @issue?.annotation
     subtasks = ((@subtasks[type]?.map (range) -> range.annotation) for type of @subtasks)
-    subtasks = subtasks.reduce (a, b) -> [a..., b...]
-    {issue, subtasks}
+    if subtasks.length
+      subtasks = subtasks.reduce (a, b) -> [a..., b...]
+    value.type = @type
+    value.details = subtasks
+    value
   
   destroy: ->
     @issue?.destroy()

--- a/app/lib/annotation-tool.coffee
+++ b/app/lib/annotation-tool.coffee
@@ -43,7 +43,8 @@ class AnnotationTool
   
   value: ->
     issue = @issue?.annotation
-    subtasks = (@subtasks[type]?.map (range) -> range.annotation) for type of @subtasks
+    subtasks = ((@subtasks[type]?.map (range) -> range.annotation) for type of @subtasks)
+    subtasks = subtasks.reduce (a, b) -> [a..., b...]
     {issue, subtasks}
   
   destroy: ->

--- a/app/lib/subjects.coffee
+++ b/app/lib/subjects.coffee
@@ -8,15 +8,15 @@ class Subjects
   
   constructor: (@api, @project, @subject_set_id)->
     @query.workflow_id = @project?.links.workflows[0]
-    @query.subject_set_id = @subject_set_id
+    # @query.subject_set_id = @subject_set_id
   
   update: (opts) ->
     @[opt] = value for opt, value of opts
     @query.workflow_id = @project?.links.workflows[0]
-    @query.subject_set_id = @subject_set_id
+    # @query.subject_set_id = @subject_set_id
     
   fetch: ->
-    return Promise.resolve [] unless @query.workflow_id? && @query.subject_set_id?
+    return Promise.resolve [] unless @query.workflow_id?
     @api.type('subjects')
     .get @query
     .then (newSubjects) =>

--- a/app/lib/subjects.coffee
+++ b/app/lib/subjects.coffee
@@ -8,7 +8,7 @@ class Subjects
     include: ['subject_sets']
   
   constructor: (@api, @project, @subject_set_id)->
-    @query.workflow_id = @project?.links.workflows[0]
+    @query.workflow_id = '2368'
     # @query.subject_set_id = @subject_set_id
   
   update: (opts) ->

--- a/app/lib/subjects.coffee
+++ b/app/lib/subjects.coffee
@@ -5,6 +5,7 @@ class Subjects
   query:
     sort: 'queued'
     page_size: "30"
+    include: ['subject_sets']
   
   constructor: (@api, @project, @subject_set_id)->
     @query.workflow_id = @project?.links.workflows[0]

--- a/app/main.cjsx
+++ b/app/main.cjsx
@@ -1,6 +1,7 @@
 init = require './init'
 config = require './config'
 React = require 'react'
+ReactDOM = require 'react-dom'
 ChooseSubjectSet = require './choose-subject-set'
 Classifier = require './classifier'
 Profile = require './profile'
@@ -49,10 +50,10 @@ Main = React.createClass
     
   componentDidUpdate:->
     @setBackground @state.project if @state.project?
-    React.render <Profile project={@state.project} workflow={@state.workflow} user={@state.user} api={@client} />, document.querySelector '#profile'
-    React.render <UserStatus user={@state.user} auth={@auth} onSignOut={@signOut} />, document.querySelector '#user-status'
-    React.render <ChooseSubjectSet workflow={@state.workflow} onChange={@changeSubjectSet} />, document.querySelector '#reports'
-    React.render <Page project={@state.project} url_key='science_case' />, document.querySelector '#about'
+    ReactDOM.render <Profile project={@state.project} workflow={@state.workflow} user={@state.user} api={@client} />, document.querySelector '#profile'
+    ReactDOM.render <UserStatus user={@state.user} auth={@auth} onSignOut={@signOut} />, document.querySelector '#user-status'
+    ReactDOM.render <ChooseSubjectSet workflow={@state.workflow} onChange={@changeSubjectSet} />, document.querySelector '#reports'
+    ReactDOM.render <Page project={@state.project} url_key='science_case' />, document.querySelector '#about'
     @renderClassifier()
   
   componentDidMount: ->
@@ -113,9 +114,9 @@ Main = React.createClass
   
   renderClassifier: ->
     if @state.subject_set?
-      React.render <Classifier project={@state.project} workflow={@state.workflow} user={@state.user} api={@client} talk={@talk} subject_set={@state.subject_set} />, document.querySelector '#classify'
+      ReactDOM.render <Classifier project={@state.project} workflow={@state.workflow} user={@state.user} api={@client} talk={@talk} subject_set={@state.subject_set} />, document.querySelector '#classify'
     else
-      React.render <ChooseSubjectSet workflow={@state.workflow} onChange={@changeSubjectSet} />, document.querySelector '#classify'
+      ReactDOM.render <ChooseSubjectSet workflow={@state.workflow} onChange={@changeSubjectSet} />, document.querySelector '#classify'
   
   startTutorial: ->
     document.querySelector('#classify').removeEventListener 'activate', @startTutorial
@@ -130,4 +131,4 @@ Main = React.createClass
                 <Tutorial tutorial={tutorial} api={@client} user={@state.user} project={@state.project} onFinish={resolve} />
           
             
-React.render <Main />, document.querySelector '#home'
+ReactDOM.render <Main />, document.querySelector '#home'

--- a/app/main.cjsx
+++ b/app/main.cjsx
@@ -92,7 +92,7 @@ Main = React.createClass
         @projects?.fetch().then =>
           project = @projects.current()
           @client.type 'workflows'
-            .get project.links.workflows[0]
+            .get '2368'
             .then (workflow) =>
               @setState {user, project, workflow}
   

--- a/app/main.cjsx
+++ b/app/main.cjsx
@@ -54,7 +54,7 @@ Main = React.createClass
     ReactDOM.render <UserStatus user={@state.user} auth={@auth} onSignOut={@signOut} />, document.querySelector '#user-status'
     ReactDOM.render <ChooseSubjectSet workflow={@state.workflow} onChange={@changeSubjectSet} />, document.querySelector '#reports'
     ReactDOM.render <Page project={@state.project} url_key='science_case' />, document.querySelector '#about'
-    @renderClassifier()
+    ReactDOM.render <Classifier project={@state.project} workflow={@state.workflow} user={@state.user} api={@client} talk={@talk} subject_set={@state.subject_set} />, document.querySelector '#classify'
   
   componentDidMount: ->
     document.querySelector('#classify').addEventListener 'activate', @startTutorial
@@ -67,7 +67,7 @@ Main = React.createClass
       </div>
       <div className="readymade-project-summary"> {@state.project?.description} </div>
       <div className="readymade-project-description"> {@state.project?.introduction} </div>
-      {<div className="readymade-footer"> <a href="#/#{ if @state.subject_set? then 'classify' else 'reports'}" className="major-button"> Get started! </a> </div> if @state.project?}
+      {<div className="readymade-footer"> <a href="#/classify" className="major-button"> Get started! </a> </div> if @state.project?}
       <ProjectStatistics project={@state.project} workflow={@state.workflow} />
     </div>
   

--- a/app/main.cjsx
+++ b/app/main.cjsx
@@ -2,7 +2,7 @@ init = require './init'
 config = require './config'
 React = require 'react'
 ReactDOM = require 'react-dom'
-ChooseSubjectSet = require './choose-subject-set'
+# ChooseSubjectSet = require './choose-subject-set'
 Classifier = require './classifier'
 Profile = require './profile'
 Page = require './page'
@@ -52,7 +52,7 @@ Main = React.createClass
     @setBackground @state.project if @state.project?
     ReactDOM.render <Profile project={@state.project} workflow={@state.workflow} user={@state.user} api={@client} />, document.querySelector '#profile'
     ReactDOM.render <UserStatus user={@state.user} auth={@auth} onSignOut={@signOut} />, document.querySelector '#user-status'
-    ReactDOM.render <ChooseSubjectSet workflow={@state.workflow} onChange={@changeSubjectSet} />, document.querySelector '#reports'
+    # ReactDOM.render <ChooseSubjectSet workflow={@state.workflow} onChange={@changeSubjectSet} />, document.querySelector '#reports'
     ReactDOM.render <Page project={@state.project} url_key='science_case' />, document.querySelector '#about'
     ReactDOM.render <Classifier project={@state.project} workflow={@state.workflow} user={@state.user} api={@client} talk={@talk} subject_set={@state.subject_set} />, document.querySelector '#classify'
   

--- a/app/panoptes/account-bar.cjsx
+++ b/app/panoptes/account-bar.cjsx
@@ -28,8 +28,7 @@ module.exports = React.createClass
 
   handleSignOutClick: ->
     @props.auth.signOut()
-    .catch =>
-      @props.onSignOut()
+    @props.onSignOut()
 
   toggleAccountMenu: ->
     @setState expanded: !@state.expanded

--- a/app/panoptes/alert.cjsx
+++ b/app/panoptes/alert.cjsx
@@ -1,4 +1,5 @@
 React = require 'react'
+ReactDOM = require 'react-dom'
 Dialog = require './dialog'
 
 module.exports = (message) ->
@@ -20,12 +21,12 @@ module.exports = (message) ->
   previousActiveElement = document.activeElement
 
   closeButton = <button aria-label='Close' onClick={defer.resolve}>&times;</button>
-  React.render <Dialog className="alert" controls={closeButton} onEscape={defer.resolve}>
+  ReactDOM.render <Dialog className="alert" controls={closeButton} onEscape={defer.resolve}>
     {message}
   </Dialog>, container
 
   unmount = ->
-    React.unmountComponentAtNode container
+    ReactDOM.unmountComponentAtNode container
     container.parentNode.removeChild container
     previousActiveElement?.focus()
 

--- a/app/panoptes/dialog.cjsx
+++ b/app/panoptes/dialog.cjsx
@@ -1,4 +1,5 @@
 React = require 'react'
+ReactDOM = require 'react-dom'
 
 FOCUSABLES = "a[href], area[href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), button:not([disabled]), iframe, object, embed, *[tabindex], *[contenteditable]"
 
@@ -32,7 +33,7 @@ module.exports = React.createClass
 
       when TAB_KEY
         {shiftKey} = e # Save this; React recycles the event object.
-        focusables = @getDOMNode().querySelectorAll FOCUSABLES
+        focusables = ReactDOM.findDOMNode(@).querySelectorAll FOCUSABLES
         if shiftKey and document.activeElement == focusables[0]
           focusables[focusables.length - 1]?.focus()
           e.preventDefault()

--- a/css/custom.styl
+++ b/css/custom.styl
@@ -1,3 +1,24 @@
+.health
+  background: #ff6639
+  
+  &:hover
+    background: #ff3900
+
+.work
+  background: #ffa539
+  
+  &:hover
+    background: #ff8b00
+
+.food
+  background: #5364fd
+  
+  &:hover
+    background: #0f25f5
+
+.housing
+  background: #43bcfd
+
 .readymade-subject-viewer-container
   
   .readymade-subject-viewer
@@ -134,15 +155,13 @@
   text-align: center
   
 .highlight
-  color: black
-  background: #ddd
+  color: #fff
   
   &.complete
     opacity: 0.6
 
 .annotation
   width: 100%
-  background: #283f45
   color: #fff
   
   button

--- a/css/custom.styl
+++ b/css/custom.styl
@@ -40,7 +40,10 @@
   padding-right: .5vw
 
 .readymade-marking-surface-container
-  display: flex
+  display: none
+  
+  &.active
+    display: block
   
   &.image
     .subject-image

--- a/css/custom.styl
+++ b/css/custom.styl
@@ -41,11 +41,14 @@
 
 .readymade-marking-surface-container
   display: flex
-  opacity: 0.2
   
-  &.current
-  &.active
-    opacity: 1
+  &.image
+    .subject-image
+      display: block
+      text-align: center
+    
+    .text-viewer
+      display: none
   
 .text-viewer
   flex: 5
@@ -62,7 +65,6 @@
   
   img
     width: 100%
-    max-width: 500px
     
 .text-selection
   background: #0b517c
@@ -79,11 +81,22 @@
     &:hover
       background: rgba(0, 0, 0, 0.3)
 
-.decision-tree-choice
-  margin-bottom: .5em
+.readymade-decision-tree-container
+  .decision-tree-choice
+    display: block
+    margin-bottom: .5em
   
-  .decision-tree-choices
-    margin-top: .5em
+    .decision-tree-choices
+      margin-top: .5em
+    
+    input[type=radio]
+      position: absolute
+      height: 1px
+      width: 1px
+      opacity: 0
+  
+      &:checked + span
+        background: #0b517c
     
 .readymade-choice-clickable
   color: white

--- a/css/custom.styl
+++ b/css/custom.styl
@@ -1,4 +1,4 @@
-.health
+.pollution
   background: #ff6639
   
   &:hover

--- a/css/custom.styl
+++ b/css/custom.styl
@@ -305,13 +305,10 @@ button[disabled]
   
   h2
     font-size: 1em
-    background: #283f45
-    margin-bottom: 0
-    padding: .5em
-    
-    & + p
-      margin-top: 0
-      text-align: center
+    margin-bottom: .5em
+  
+  .annotation
+    margin-bottom: .5em
       
 .readymade-field-guide-container
   position: absolute

--- a/css/custom.styl
+++ b/css/custom.styl
@@ -34,6 +34,30 @@
       color: white
       font-size: 1em
       padding: .2em .4em
+    
+    .image-toggle
+      background: #0b517c
+      border: 0
+      color: white
+      float: right
+      padding: 0
+      border: 0
+      border-radius: 1px
+      font-size: 1.2em
+      
+      input[type=checkbox]
+        position: absolute
+        height: 0
+        width: 0
+        opacity: 0
+      
+      span
+        background: rgba(0, 0, 0, 0.1)
+        padding: .2em .4em
+        
+        &.active
+          background: rgba(0, 0, 0, 0.3)
+        
 
 .readymade-decision-tree-container
   padding-left: 0

--- a/css/custom.styl
+++ b/css/custom.styl
@@ -8,7 +8,8 @@
     
     .drawing-controls
       display: block
-      background: #283f45
+      background: #0b517c
+      color: #fff
       text-align: right
       margin: 0
       
@@ -36,7 +37,7 @@
         
     
     h3
-      background: #283f45
+      background: #0b517c
       color: white
       font-size: 1em
       padding: .2em .4em
@@ -71,7 +72,8 @@
     max-width: 500px
     
 .text-selection
-  background: #283f45
+  background: #0b517c
+  color: #fff
   margin: 0
   padding: .5em .2em
   
@@ -108,6 +110,7 @@
 .annotation
   width: 100%
   background: #283f45
+  color: #fff
   
   button
     float: right
@@ -162,39 +165,40 @@ button[disabled]
 
 .reports
 
-    ul
-      list-style-type: none
-      margin: 1em 0 0
-      padding: 0
-      text-indent: 0
-  
-      li
-        display: inline-block
-        width: 20%
-        
-        a
-          color: white
-          text-decoration: none
-          padding: 1em
-          margin-right: 1em
-          margin-bottom: .5em
-          border-radius: 5px
-          display: inline-block
-          width: 80%
-          vertical-align: middle
-          text-align: left
-          color: #fff
-          background: #000
-          background: rgba( 0, 0, 0, .5)
-          border: 1px solid transparent
+  ul
+    list-style-type: none
+    margin: 1em 0 0
+    padding: 0
+    text-indent: 0
+    color: white
 
-          &:hover
-          &:focus
-            background: #000
+  li
+    display: inline-block
+    width: 20%
+
+  a
+    color: white
+    text-decoration: none
+    padding: 1em
+    margin-right: 1em
+    margin-bottom: .5em
+    border-radius: 5px
+    display: inline-block
+    width: 80%
+    vertical-align: middle
+    text-align: left
+    color: #fff
+    background: #000
+    background: rgba( 0, 0, 0, .5)
+    border: 1px solid transparent
+
+    &:hover
+    &:focus
+      background: #000
 
 .column
-  background: #000
-  background: rgba(0, 0, 0, .4)
+  background: #fff
+  background: rgba(255, 255, 255, .8)
   padding: 1em
 
 #profile
@@ -239,7 +243,7 @@ button[disabled]
   padding: .5em
   border-radius: .5em
   background: #333
-  background: rgba(0, 0, 0, 0.5)
+  background: rgba(255, 255, 255, 0.8)
   margin-bottom: .5em
   
   .major-button
@@ -275,4 +279,12 @@ button[disabled]
   &[aria-hidden=true]
     display: block
     width: 0
+
+.main-footer
+  background: #0b517c
+  color: #fff
+  
+  .site-map-section
+    h6
+      color: #999
 

--- a/css/custom.styl
+++ b/css/custom.styl
@@ -20,10 +20,9 @@
   background: #43bcfd
 
 .readymade-subject-viewer-container
+  padding: 0 .5em
   
   .readymade-subject-viewer
-    width: 55vw
-    max-width: 700px
     background: #eee
     background: rgba(256,256,230,0.75)
     
@@ -81,8 +80,7 @@
         
 
 .readymade-decision-tree-container
-  padding-left: 0
-  padding-right: .5vw
+  padding: 0
 
 .readymade-marking-surface-container
   display: none

--- a/css/custom.styl
+++ b/css/custom.styl
@@ -1,8 +1,8 @@
 .readymade-subject-viewer-container
   
   .readymade-subject-viewer
-    width: 75vw
-    max-width: 950px
+    width: 55vw
+    max-width: 700px
     background: #eee
     background: rgba(256,256,230,0.75)
     
@@ -10,19 +10,12 @@
       display: block
       background: #0b517c
       color: #fff
-      text-align: right
-      margin: 0
+      padding: 0.2em
       
       h2
-        display: inline-block
-        width: 45%
         text-align: left
         font-size: .9em
-    
-      .tools
-        display: inline-block
-        text-align: right
-        width: 55%
+        margin: 0.2em 0.3em
       
       .readymade-clickable
         background: rgba(0, 0, 0, 0.1)
@@ -58,14 +51,14 @@
   flex: 5
   min-height: 60vh
   color: #222
-  max-width: 450px
+  max-width: 100%
   margin: 0
   
   div
     padding: 1em
 
 .subject-image
-  flex: 3
+  display: none
   
   img
     width: 100%
@@ -240,6 +233,7 @@ button[disabled]
 .readymade-classification-summary
 .task-instructions
 .annotation-summary
+  font-size: 0.9em
   padding: .5em
   border-radius: .5em
   background: #333
@@ -265,6 +259,7 @@ button[disabled]
 .readymade-field-guide-container
   position: absolute
   right: 0
+  top: 5em
   z-index: 1
   overflow: hidden
   width: 30em

--- a/css/decision-tree.styl
+++ b/css/decision-tree.styl
@@ -7,7 +7,7 @@
 
     .decision-tree-question
       text-align: left
-      margin: 2em 0
+      margin: 0 0 1em
 
     button[name="decision-tree-confirm-task"]
       @extends #_DECISION_TREE_META_BUTTON

--- a/css/header.styl
+++ b/css/header.styl
@@ -2,6 +2,7 @@
   padding: 20px 5vw 0
   background: #000
   background: rgba( 0, 0, 0, 0.5)
+  color: white
   display: flex
 
   .readymade-project-title
@@ -18,11 +19,9 @@
 
   .readymade-site-link
     border-radius: 3px
-    color: inherit
     display: inline-block
-    font-size: 12px
-    font-weight: bold
-    letter-spacing: 2px
+    font-size: .8em
+    color: #fff
     padding: 0.5em 1em
     text-decoration: none
     text-transform: uppercase
@@ -32,7 +31,8 @@
       background: rgba(white, 0.25)
 
     &[aria-selected=true]
-      background: rgba(white, 0.5)
+      background: rgba(white, 0.2)
+      font-weight: bold
     
     &[aria-hidden=true]
       display: none

--- a/css/layout.styl
+++ b/css/layout.styl
@@ -1,15 +1,17 @@
 html
-  background: black
-  color: white
+  background: white
+  color: black
   font: 14px/1.5 "Open Sans", Arial, sans-serif
 
 body
   margin: 0
 
 h1
+  font-size: 3em
   margin: 0
 
 h2
+  font-size: 1.2em
   line-height: inherit
 
 .readymade-site-background
@@ -18,7 +20,7 @@ h2
   background-size: cover
   bottom: 0
   left: 0
-  opacity: 0.9
+  opacity: 0.6
   position: fixed
   right: 0
   top: 0
@@ -49,12 +51,10 @@ h2
 
 h1
   font-weight: 100
-  font-size: 64px
   line-height: 1
 
 h2
   font-weight: 100
-  font-size: 36px
   line-height: 1
 
 h3

--- a/css/layout.styl
+++ b/css/layout.styl
@@ -18,7 +18,7 @@ h2
   background-size: cover
   bottom: 0
   left: 0
-  opacity: 0.5
+  opacity: 0.9
   position: fixed
   right: 0
   top: 0

--- a/css/panoptes/typography.styl
+++ b/css/panoptes/typography.styl
@@ -1,5 +1,5 @@
 html
-  font: 400 15px/1.5 "Open Sans", "Gill Sans", Arial, sans-serif
+  font: 400 14px/1.5 "Open Sans", "Gill Sans", Arial, sans-serif
 
 .attribution
   font-size: 0.7em

--- a/css/project-metadata.styl
+++ b/css/project-metadata.styl
@@ -1,6 +1,7 @@
 .project-metadata
   background: #000
   background: rgba(0, 0, 0, .8)
+  color: #fff
   min-height: 199px
   padding: 2em 0
   text-align: center

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
   "dependencies": {
     "markdown-it": "~4.4.0",
     "publisssh": "~1.0.0",
-    "react": "0.13.3"
+    "react": "~0.14.1",
+    "react-dom": "~0.14.1"
   },
   "config": {
     "fontAwesomeURL": "https://github.com/FortAwesome/Font-Awesome/blob/8027c940b6/assets/font-awesome-4.2.0.zip?raw=true",

--- a/public/index.html
+++ b/public/index.html
@@ -30,7 +30,7 @@
         <header id="main-header" role="banner" class="readymade-site-header"> 
           <ul class="readymade-site-links" role="navigation">
             <li><a href="#home" class="readymade-site-link">Diagnosis London</a></li>
-            <li><a href="#reports" class="readymade-site-link">Reports</a></li>
+            <!-- <li><a href="#reports" class="readymade-site-link">Reports</a></li> -->
             <li><a href="#classify" class="readymade-site-link">Classify</a></li>
             <li><a aria-hidden="true" href="#profile" class="readymade-site-link">Profile</a></li>
             <li><a href="#about" class="readymade-site-link">About</a></li>
@@ -45,9 +45,9 @@
           <div class="readymade-home-page" id="home">
           
           </div>
-          <div class="readymade-classifier readymade-classify-page" id="reports">
-            
-          </div>
+          <!-- <div class="readymade-classifier readymade-classify-page" id="reports">
+
+          </div> -->
           <div class="readymade-classifier readymade-classify-page" id="classify">
             
           </div>


### PR DESCRIPTION
- [x] white-on-black colour scheme was generally felt to be too dark.
- [x] add an initial yes/no step to quickly filter pages that have no useful information.
- [x] allow people to mark up text at the category choices step.
- [ ] wording could be changed to make the text marking task more explicit (people were confused as to what they should be looking for in the text.)
- [x] implement randomised subject selection, rather than working through each set in order.
- [x] link up each subject page to its previous and next neighbours, as per https://github.com/zooniverse/old-weather/issues/95 and https://github.com/zooniverse/shakespeares_world/issues/296 Ideally, randomly select the entry point into the collection, then grab the pages either side of that.
- [x] update the classification output to conform with the format produced by project builder tasks.
- [x] add a toggle to switch between OCR text and the original, scanned page.
- [x] look up subject set metadata correctly when subjects are served randomly.
